### PR TITLE
Remove ng-content-editable from bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,7 @@
     "bower_components"
   ],
   "dependencies": {
-    "angular": "> 1.2.0 < 2.0",
-    "ng-content-editable": "*"
+    "angular": "> 1.2.0 < 2.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
This recursive dependency is causing issues with grunt-wiredep.
It falls on an endless loop when tries to get the ng-content-editable's dependencies.